### PR TITLE
Update test-and-release.yml to use node 16/18/20

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           lint: true
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -65,7 +65,7 @@ jobs:
 #    steps:
 #      - uses: ioBroker/testing-action-deploy@v1
 #        with:
-#          node-version: '14.x'
+#          node-version: '18.x'
 #          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
 #          # install-command: 'npm install'
 #          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Node 12 and 14 are no longer supported by ioBroker.
So this PR adapts testing environment to use node 16/18/20 which are the currently supported node releases.

Please note that active github tests are required for the adapter to be updated at stable repository and to stay active at latest repository. So please check und merge this PR (or setup tests be yourself).

In addtion the standard workflow could provide an integrated publish ar npm. So if you want to use this feature simply uncomment the relevant sequence and add an npm_token. If desired I can provide a second PR with this extension. Of course its ok if you prefer to do those steps manually. 