### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           lint: true
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -65,7 +65,7 @@ jobs:
 #    steps:
 #      - uses: ioBroker/testing-action-deploy@v1
 #        with:
-#          node-version: '14.x'
+#          node-version: '18.x'
 #          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
 #          # install-command: 'npm install'
 #          npm-token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "git+https://github.com/Chris-656/ioBroker.fitbit-fitness.git"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "type": "git",
     "url": "git+https://github.com/Chris-656/ioBroker.fitbit-fitness.git"
   },
-  "engines": {
-    "node": ">= 16"
-  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.5.0",


### PR DESCRIPTION
adapter-code 3.x.x is known to fail when installed at node 14 or lower as npm 6 does not install required peerDependencies. So this adapter must require node 16 or newer.